### PR TITLE
fix: Fix Docker production build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:24-alpine AS builder
 
-ENV NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 WORKDIR /app
 
@@ -12,6 +11,8 @@ COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install
 
 COPY . .
+RUN yarn generate
+ENV NODE_ENV=production
 RUN yarn build
 
 FROM node:24-alpine AS dev

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",
+    "language-subtag-registry": "^0.3.23",
     "lucide-react": "^0.556.0",
     "newrelic": "^13.7.0",
     "next": "16.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8533,6 +8533,7 @@ __metadata:
     eslint-config-next: "npm:16.0.7"
     ioredis: "npm:^5.8.2"
     jest: "npm:^30.2.0"
+    language-subtag-registry: "npm:^0.3.23"
     lucide-react: "npm:^0.556.0"
     newrelic: "npm:^13.7.0"
     next: "npm:16.1.5"
@@ -10340,7 +10341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"language-subtag-registry@npm:^0.3.20":
+"language-subtag-registry@npm:^0.3.20, language-subtag-registry@npm:^0.3.23":
   version: 0.3.23
   resolution: "language-subtag-registry@npm:0.3.23"
   checksum: 10c0/e9b05190421d2cd36dd6c95c28673019c927947cb6d94f40ba7e77a838629ee9675c94accf897fbebb07923187deb843b8fbb8935762df6edafe6c28dcb0b86c


### PR DESCRIPTION
## Summary
- **Remove `NODE_ENV=production` from builder install phase** so devDependencies (`@tailwindcss/postcss`, `tailwindcss`, `typescript`) are installed and available during `yarn build`
- **Add `yarn generate` step** before `yarn build` in Dockerfile to create `.mercato/generated/*` files that the app imports
- **Add `language-subtag-registry`** as a production dependency (required by `@open-mercato/shared` at build time)

## Test plan
- [ ] Deploy via Dokploy and verify the Docker build completes successfully
- [ ] Verify the app starts and serves pages correctly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)