### PR TITLE
fix: Enable planner module to fix production build

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -28,7 +28,7 @@ export const enabledModules: ModuleEntry[] = [
   { id: 'workflows', from: '@open-mercato/core' },
   { id: 'search', from: '@open-mercato/search' },
   { id: 'currencies', from: '@open-mercato/core' },
-  // { id: 'planner', from: '@open-mercato/core' },
+  { id: 'planner', from: '@open-mercato/core' },
   // { id: 'resources', from: '@open-mercato/core' },
   { id: 'staff', from: '@open-mercato/core' },
   { id: 'events', from: '@open-mercato/events' },


### PR DESCRIPTION
## Summary
- Enable the `planner` core module which the `staff` module depends on
- The `staff` module's `leave-requests.ts` references `E.planner.planner_availability_rule`, causing a TypeScript build failure when `planner` is not registered

## Test plan
- [ ] Verify Docker production build completes without type errors
- [ ] Verify planner module loads correctly in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)