### PR TITLE
fix: Add missing createdAt to CompetitionInvitation

### DIFF
--- a/src/modules/competitions/api/admin/bulk-invite/route.ts
+++ b/src/modules/competitions/api/admin/bulk-invite/route.ts
@@ -126,6 +126,7 @@ export async function POST(req: Request) {
           participationRole: invitee.role,
           tenantId,
           organizationId,
+          createdAt: new Date(),
         })
         em.persist(competitionInvitation)
 


### PR DESCRIPTION
## Summary
- Add explicit `createdAt: new Date()` to `em.create(CompetitionInvitation, ...)` in the bulk-invite route
- MikroORM's strict typing requires the property even though the entity defines a default value and `onCreate` hook

## Test plan
- [ ] Verify Docker production build completes without type errors
- [ ] Verify bulk invite functionality still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)