### PR TITLE
fix: Correct Docker COPY path for Next.js build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN corepack enable
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN yarn install --production=true
 
-COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/.mercato/next ./.mercato/next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/types ./types


### PR DESCRIPTION
## Summary
- Fix `COPY --from=builder /app/.next` → `COPY --from=builder /app/.mercato/next` in Dockerfile
- `next.config.ts` sets `distDir: '.mercato/next'`, so the build output is at `.mercato/next`, not `.next`

## Test plan
- [ ] Verify Docker production build completes and container starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)