### PR TITLE
fix: Use curl instead of wget for Meilisearch health check

### DIFF
--- a/docker-compose.fullapp.dev.yml
+++ b/docker-compose.fullapp.dev.yml
@@ -100,7 +100,7 @@ services:
     volumes:
       - meilisearch_data:/meili_data
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7700/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -100,7 +100,7 @@ services:
     volumes:
       - meilisearch_data:/meili_data
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7700/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- Meilisearch container was marked unhealthy on Dokploy deployment because `wget` is not available in the `getmeili/meilisearch:v1.11` image
- Replaced `wget -q --spider` with `curl -f` in health checks for both `docker-compose.fullapp.yml` and `docker-compose.fullapp.dev.yml`

## Test plan
- [ ] Deploy to Dokploy and verify Meilisearch container passes health check
- [ ] Verify app container starts successfully after Meilisearch is healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)