### PR TITLE
fix: Skip tenant guard for portal login endpoints

### DIFF
--- a/src/app/api/[...slug]/route.ts
+++ b/src/app/api/[...slug]/route.ts
@@ -122,7 +122,7 @@ async function checkAuthorization(
     return container
   }
 
-  if (auth && methodMetadata?.requireAuth !== false) {
+  if (auth && methodMetadata && methodMetadata.requireAuth !== false) {
     const rawTenantCandidate = await extractTenantCandidate(req)
     if (rawTenantCandidate !== undefined) {
       const tenantCandidate = sanitizeTenantCandidate(rawTenantCandidate)


### PR DESCRIPTION
## Summary
- Fixed "Not authorized to target this tenant" error on mobile portal login
- The API route handler's tenant guard was running on endpoints without method-level metadata (like `customer_accounts/login`), causing a stale admin `auth_token` cookie to trigger a cross-tenant rejection
- Changed the guard condition to only enforce tenant selection when method metadata is explicitly defined

## Test plan
- [ ] Login to admin backend, then navigate to portal login on the same domain — should no longer show tenant error
- [ ] Login on mobile with a customer account — should succeed
- [ ] Verify admin-authenticated API routes still enforce tenant boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)