### PR TITLE
Fix sponsor/prize edit 404 and improve drawer UI contrast

### DIFF
--- a/src/components/portal/CompetitionGuideDrawer.tsx
+++ b/src/components/portal/CompetitionGuideDrawer.tsx
@@ -230,7 +230,7 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                             'flex size-8 items-center justify-center rounded-full border transition-all',
                             state === 'completed' && 'border-emerald-500/50 bg-emerald-500/20 text-emerald-400',
                             state === 'current' && 'border-portal-primary bg-portal-primary text-white shadow-[0_0_12px_rgba(79,70,229,0.4)]',
-                            state === 'upcoming' && 'border-white/8 bg-white/[0.03] text-gray-600',
+                            state === 'upcoming' && 'border-white/8 bg-white/[0.03] text-gray-500',
                           )}
                         >
                           {state === 'completed' ? <Check className="size-3.5" strokeWidth={2.5} /> : <span className="text-[11px] font-bold tabular-nums">{index + 1}</span>}
@@ -243,7 +243,7 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                           'flex-1 rounded-2xl border transition-all',
                           state === 'current' && 'border-portal-primary/30 bg-gradient-to-br from-portal-primary/[0.08] to-portal-primary/[0.02]',
                           state === 'completed' && 'border-white/8 bg-white/[0.03]',
-                          state === 'upcoming' && 'border-white/5 bg-white/[0.015]',
+                          state === 'upcoming' && 'border-white/8 bg-white/[0.025]',
                         )}
                       >
                         {/* Card header */}
@@ -255,20 +255,20 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                                   'inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.15em]',
                                   state === 'completed' && 'bg-emerald-500/10 text-emerald-400',
                                   state === 'current' && 'bg-portal-primary/15 text-portal-primary-light',
-                                  state === 'upcoming' && 'bg-white/5 text-gray-500',
+                                  state === 'upcoming' && 'bg-white/6 text-gray-400',
                                 )}>
                                   {formatStateLabel(state, t)}
                                 </span>
                               </div>
                               <h3 className={cn(
                                 'mt-2 text-[15px] font-bold leading-snug sm:text-base',
-                                state === 'upcoming' ? 'text-gray-400' : 'text-white',
+                                state === 'upcoming' ? 'text-gray-300' : 'text-white',
                               )}>
                                 {stage.title}
                               </h3>
                               <p className={cn(
                                 'mt-1.5 text-[13px] leading-relaxed',
-                                state === 'upcoming' ? 'text-gray-600' : 'text-gray-400',
+                                state === 'upcoming' ? 'text-gray-500' : 'text-gray-400',
                               )}>
                                 {stage.summary}
                               </p>
@@ -277,7 +277,7 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                               'flex size-9 shrink-0 items-center justify-center rounded-xl border',
                               state === 'current' && 'border-portal-primary/30 bg-portal-primary/10 text-portal-primary-light',
                               state === 'completed' && 'border-emerald-500/20 bg-emerald-500/5 text-emerald-400/70',
-                              state === 'upcoming' && 'border-white/5 bg-white/[0.02] text-gray-600',
+                              state === 'upcoming' && 'border-white/8 bg-white/[0.03] text-gray-500',
                             )}>
                               <Icon className="size-4" />
                             </div>
@@ -289,7 +289,7 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                           'border-t px-4 py-3 sm:px-5',
                           state === 'current' && 'border-portal-primary/15',
                           state === 'completed' && 'border-white/5',
-                          state === 'upcoming' && 'border-white/[0.03]',
+                          state === 'upcoming' && 'border-white/5',
                         )}>
                           <div className="space-y-1.5">
                             {stage.tasks.map((task) => (
@@ -301,11 +301,11 @@ export function CompetitionGuideDrawer({ open, onClose, currentStage }: Competit
                                   'mt-0.5 size-3.5 shrink-0',
                                   state === 'completed' && 'text-emerald-500/40',
                                   state === 'current' && 'text-portal-primary-light/60',
-                                  state === 'upcoming' && 'text-gray-700',
+                                  state === 'upcoming' && 'text-gray-600',
                                 )} />
                                 <p className={cn(
                                   'text-[12.5px] leading-relaxed',
-                                  state === 'upcoming' ? 'text-gray-600' : 'text-gray-400',
+                                  state === 'upcoming' ? 'text-gray-500' : 'text-gray-400',
                                 )}>
                                   {task}
                                 </p>

--- a/src/components/portal/MilestonesDrawer.tsx
+++ b/src/components/portal/MilestonesDrawer.tsx
@@ -106,8 +106,8 @@ export function MilestonesDrawer({ competitionId, open, onClose, orgSlug, rulesU
                             <div className="size-3 rounded-full bg-white" />
                           </div>
                         ) : (
-                          <div className="size-8 rounded-full bg-gray-700 flex items-center justify-center">
-                            <div className="size-2.5 rounded-full bg-gray-500" />
+                          <div className="size-8 rounded-full bg-gray-700/60 flex items-center justify-center">
+                            <div className="size-2.5 rounded-full bg-gray-400" />
                           </div>
                         )}
                       </div>
@@ -118,15 +118,13 @@ export function MilestonesDrawer({ competitionId, open, onClose, orgSlug, rulesU
                           'flex-1 rounded-xl px-4 py-3 mb-4 transition-colors',
                           isActive
                             ? 'bg-white/10 border border-white/10'
-                            : isUpcoming
-                              ? 'opacity-50'
-                              : '',
+                            : '',
                         )}
                       >
                         <h4
                           className={cn(
                             'text-sm font-bold',
-                            isCompleted ? 'text-white' : isActive ? 'text-white' : 'text-gray-400',
+                            isCompleted ? 'text-white' : isActive ? 'text-white' : 'text-gray-300',
                           )}
                         >
                           {milestone.name}
@@ -148,7 +146,7 @@ export function MilestonesDrawer({ competitionId, open, onClose, orgSlug, rulesU
                         {milestone.description && (
                           <p className={cn(
                             'text-xs mt-1.5 leading-relaxed',
-                            isUpcoming ? 'text-gray-600' : 'text-gray-400',
+                            isUpcoming ? 'text-gray-500' : 'text-gray-400',
                           )}>
                             {milestone.description}
                           </p>

--- a/src/modules/sponsors/backend/prizes/[id]/edit/page.tsx
+++ b/src/modules/sponsors/backend/prizes/[id]/edit/page.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
 import { updateCrud, fetchCrudList } from '@open-mercato/ui/backend/utils/crud'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useQuery } from '@tanstack/react-query'
@@ -30,11 +29,10 @@ export default function EditPrizePage({ params }: { params?: { id?: string } }) 
   const { data, isLoading, error } = useQuery({
     queryKey: ['prize-edit', id],
     queryFn: async () => {
-      const { ok, result } = await apiCall<{ item: Record<string, unknown> }>(
-        `/api/sponsors/prizes/${id}`,
-      )
-      if (!ok || !result?.item) throw new Error('Failed to load prize')
-      return result.item
+      const res = await fetchCrudList<Record<string, unknown>>('sponsors/prizes', { id: id!, pageSize: '1' })
+      const item = res?.items?.[0]
+      if (!item) throw new Error('Failed to load prize')
+      return item
     },
     enabled: !!id,
   })

--- a/src/modules/sponsors/backend/sponsors/[id]/edit/page.tsx
+++ b/src/modules/sponsors/backend/sponsors/[id]/edit/page.tsx
@@ -4,7 +4,6 @@ import * as React from 'react'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
 import { updateCrud, fetchCrudList } from '@open-mercato/ui/backend/utils/crud'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { LoadingMessage, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useQuery } from '@tanstack/react-query'
@@ -23,11 +22,10 @@ export default function EditSponsorPage({ params }: { params?: { id?: string } }
   const { data, isLoading, error } = useQuery({
     queryKey: ['sponsor-edit', sponsorId],
     queryFn: async () => {
-      const { ok, result } = await apiCall<{ item: Record<string, unknown> }>(
-        `/api/sponsors/sponsors/${sponsorId}`,
-      )
-      if (!ok || !result?.item) throw new Error('Failed to load sponsor')
-      return result.item
+      const res = await fetchCrudList<Record<string, unknown>>('sponsors/sponsors', { id: sponsorId!, pageSize: '1' })
+      const item = res?.items?.[0]
+      if (!item) throw new Error('Failed to load sponsor')
+      return item
     },
     enabled: !!sponsorId,
   })


### PR DESCRIPTION
## Summary
- **Fix sponsor/prize edit pages returning 404**: Edit pages used `apiCall` with the ID as a URL path segment (`/api/sponsors/sponsors/{id}`), but the CRUD route only supports query parameters. Switched to `fetchCrudList` with `{ id, pageSize: '1' }` matching the standard pattern used by all other modules.
- **Improve drawer UI contrast**: Increased visibility of upcoming/inactive states in CompetitionGuideDrawer and MilestonesDrawer by adjusting text and border opacity values.

## Test plan
- [ ] Navigate to Backend > Sponsors & Prizes, click edit on a sponsor — should load successfully
- [ ] Click edit on a prize — should load successfully
- [ ] Verify form saves correctly after editing
- [ ] Open Competition Guide drawer — check upcoming stages are readable
- [ ] Open Milestones drawer — check upcoming milestones are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)