### PR TITLE
Add manual invite dialog for competition participants

### DIFF
--- a/src/modules/bounties/acl.ts
+++ b/src/modules/bounties/acl.ts
@@ -2,6 +2,8 @@ export const features = [
   { id: 'bounties.view', title: 'View bounty PRs', module: 'bounties' },
   { id: 'bounties.judge', title: 'Judge bounty PRs (approve/reject/override)', module: 'bounties' },
   { id: 'bounties.admin', title: 'Administer bounty settings', module: 'bounties' },
+  { id: 'portal.bounties.view', title: 'View bounty PRs from portal', module: 'bounties' },
+  { id: 'portal.bounties.register_github', title: 'Register GitHub username from portal', module: 'bounties' },
   { id: 'portal.bounties.judge', title: 'Judge bounty PRs from portal', module: 'bounties' },
 ]
 

--- a/src/modules/bounties/api/portal/submit-pr/route.ts
+++ b/src/modules/bounties/api/portal/submit-pr/route.ts
@@ -132,10 +132,12 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: `This PR belongs to @${pr.user.login}, but your registered GitHub username is @${githubUsername}` }, { status: 403 })
     }
 
-    // Check for duplicate submission
+    // Check for duplicate submission (by GitHub ID or PR number)
     const existing = await em.findOne(BountyPullRequest, {
-      githubPrId: String(pr.id),
-      tenantId: auth.tenantId,
+      $or: [
+        { githubPrId: String(pr.id), tenantId: auth.tenantId },
+        { githubPrNumber: pr.number, competitionId, tenantId: auth.tenantId, deletedAt: null },
+      ],
     } as FilterQuery<BountyPullRequest>)
 
     if (existing) {

--- a/src/modules/bounties/components/BountyDetailPanel.tsx
+++ b/src/modules/bounties/components/BountyDetailPanel.tsx
@@ -18,6 +18,7 @@ type BountyPRRow = {
   classification_confidence: number | null
   classification_summary: string | null
   total_points: number
+  points_override: Array<{ category: string; points: number; reasoning: string }> | null
   is_duplicate: boolean
   duplicate_marked_by: string | null
   split_group_id?: string | null
@@ -90,6 +91,8 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
     }
   }
 
+  const displayClassifications = pr.points_override ?? pr.classifications ?? []
+  const computedTotal = displayClassifications.reduce((sum, c) => sum + c.points, 0)
   const confidencePct = pr.classification_confidence != null ? Math.round(pr.classification_confidence * 100) : null
   const isLowConfidence = pr.classification_confidence != null && pr.classification_confidence < 0.7
 
@@ -117,10 +120,12 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
       </div>
 
       {/* LLM Classification */}
-      {pr.classifications && pr.classifications.length > 0 && (
+      {displayClassifications.length > 0 && (
         <div>
           <h4 className="text-sm font-semibold mb-2">
-            {t('bounties.detail.classification', 'LLM Classification')}
+            {pr.points_override
+              ? t('bounties.detail.overriddenClassification', 'Classification (Overridden)')
+              : t('bounties.detail.classification', 'LLM Classification')}
             {confidencePct != null && (
               <span className={`ml-2 text-xs ${isLowConfidence ? 'text-amber-600' : 'text-green-600'}`}>
                 ({confidencePct}% confidence)
@@ -128,7 +133,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
             )}
           </h4>
           <div className="space-y-1">
-            {pr.classifications.map((c, i) => (
+            {displayClassifications.map((c, i) => (
               <div key={i} className="flex items-center justify-between text-sm bg-muted/50 rounded px-3 py-1.5">
                 <span>{categoryLabels[c.category] ?? c.category}</span>
                 <span className="font-semibold">{c.points} pts</span>
@@ -139,7 +144,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
             <p className="text-xs text-muted-foreground mt-1 italic">&quot;{pr.classification_summary}&quot;</p>
           )}
           <div className="text-sm font-semibold mt-2">
-            {t('bounties.detail.total', 'Total')}: {pr.total_points} pts
+            {t('bounties.detail.total', 'Total')}: {computedTotal} pts
           </div>
         </div>
       )}

--- a/src/modules/bounties/components/BountyJudgingPanel.tsx
+++ b/src/modules/bounties/components/BountyJudgingPanel.tsx
@@ -28,6 +28,7 @@ type BountyPRRow = {
   classification_confidence: number | null
   classification_summary: string | null
   total_points: number
+  points_override: Array<{ category: string; points: number; reasoning: string }> | null
   is_duplicate: boolean
   duplicate_marked_by: string | null
   github_created_at: string

--- a/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.tsx
+++ b/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.tsx
@@ -468,7 +468,9 @@ function PRDetailPanel({ pr, onAction, onBack }: { pr: BountyPR; onAction: () =>
             </p>
           </div>
           <div className="shrink-0 flex flex-col items-center rounded-lg bg-portal-primary/5 px-3 py-2">
-            <span className="text-2xl font-bold text-portal-primary">{pr.total_points}</span>
+            <span className="text-2xl font-bold text-portal-primary">
+              {(pr.points_override ?? pr.classifications ?? []).reduce((sum, c) => sum + c.points, 0)}
+            </span>
             <span className="text-[9px] font-semibold uppercase tracking-wider text-portal-secondary">pts</span>
           </div>
         </div>
@@ -476,38 +478,43 @@ function PRDetailPanel({ pr, onAction, onBack }: { pr: BountyPR; onAction: () =>
 
       <div className="p-4 sm:p-5 space-y-4">
         {/* LLM Classification */}
-        {pr.classifications && pr.classifications.length > 0 && (
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <SectionLabel className="block">
-                {t('bounties.portal.judge.classification', 'AI CLASSIFICATION')}
-              </SectionLabel>
-              {confidencePct != null && (
-                <span className={`text-[10px] font-semibold ${isLowConfidence ? 'text-amber-600' : 'text-green-600'}`}>
-                  {confidencePct}%
-                </span>
+        {(() => {
+          const effectiveClassifications = pr.points_override ?? pr.classifications ?? []
+          return effectiveClassifications.length > 0 ? (
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <SectionLabel className="block">
+                  {pr.points_override
+                    ? t('bounties.portal.judge.overriddenClassification', 'CLASSIFICATION (OVERRIDDEN)')
+                    : t('bounties.portal.judge.classification', 'AI CLASSIFICATION')}
+                </SectionLabel>
+                {confidencePct != null && (
+                  <span className={`text-[10px] font-semibold ${isLowConfidence ? 'text-amber-600' : 'text-green-600'}`}>
+                    {confidencePct}%
+                  </span>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                {effectiveClassifications.map((c, i) => (
+                  <div key={i} className="flex items-center justify-between text-sm rounded-lg bg-gray-50 dark:bg-white/5 px-3 py-2">
+                    <div className="min-w-0 flex-1">
+                      <span className="font-medium text-foreground">{categoryLabels[c.category] ?? c.category}</span>
+                      {c.reasoning && (
+                        <p className="text-[10px] text-portal-secondary mt-0.5 line-clamp-2">{c.reasoning}</p>
+                      )}
+                    </div>
+                    <span className="font-bold text-portal-primary ml-3">{c.points} pts</span>
+                  </div>
+                ))}
+              </div>
+              {pr.classification_summary && (
+                <p className="text-[11px] text-portal-secondary mt-2 italic leading-relaxed">
+                  &quot;{pr.classification_summary}&quot;
+                </p>
               )}
             </div>
-            <div className="space-y-1.5">
-              {pr.classifications.map((c, i) => (
-                <div key={i} className="flex items-center justify-between text-sm rounded-lg bg-gray-50 dark:bg-white/5 px-3 py-2">
-                  <div className="min-w-0 flex-1">
-                    <span className="font-medium text-foreground">{categoryLabels[c.category] ?? c.category}</span>
-                    {c.reasoning && (
-                      <p className="text-[10px] text-portal-secondary mt-0.5 line-clamp-2">{c.reasoning}</p>
-                    )}
-                  </div>
-                  <span className="font-bold text-portal-primary ml-3">{c.points} pts</span>
-                </div>
-              ))}
-            </div>
-            {pr.classification_summary && (
-              <p className="text-[11px] text-portal-secondary mt-2 italic leading-relaxed">
-                &quot;{pr.classification_summary}&quot;
-              </p>
-            )}
-          </div>
-        )}
+          ) : null
+        })()}
 
         {/* Duplicate info */}
         {pr.is_duplicate && (

--- a/src/modules/bounties/widgets/injection/portal-nav/widget.ts
+++ b/src/modules/bounties/widgets/injection/portal-nav/widget.ts
@@ -40,7 +40,6 @@ const widget: InjectionMenuItemWidget = {
         labelKey: 'bounties.portal.nav.judge',
         icon: 'lucide:shield-check',
         href: `${prefix}/bounties/judge`,
-        features: ['portal.bounties.judge'],
         groupId: 'bounties',
         groupLabel: 'Bounty Hunting',
         groupLabelKey: 'bounties.portal.nav.group',

--- a/src/modules/competitions/backend/competitions/participants/page.tsx
+++ b/src/modules/competitions/backend/competitions/participants/page.tsx
@@ -16,6 +16,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import Link from 'next/link'
 import { BulkInviteDialog } from '../../../components/BulkInviteDialog'
+import { ManualInviteDialog } from '../../../components/ManualInviteDialog'
 
 type ParticipationRow = {
   id: string
@@ -65,6 +66,7 @@ export default function ParticipantsListPage() {
   const [page, setPage] = React.useState(1)
   const [filterValues, setFilterValues] = React.useState<FilterValues>({})
   const [showBulkInvite, setShowBulkInvite] = React.useState(false)
+  const [showManualInvite, setShowManualInvite] = React.useState(false)
   const [tab, setTab] = React.useState<'participants' | 'invitations'>('participants')
   const [invFilterValues, setInvFilterValues] = React.useState<FilterValues>({})
   const scopeVersion = useOrganizationScopeVersion()
@@ -236,6 +238,9 @@ export default function ParticipantsListPage() {
               <Link href="/backend/competitions/email-preview">
                 {t('competitions.participants.previewEmail', 'Preview Email')}
               </Link>
+            </Button>
+            <Button variant="outline" onClick={() => setShowManualInvite(true)}>
+              {t('competitions.participants.invite', 'Invite')}
             </Button>
             <Button variant="outline" onClick={() => setShowBulkInvite(true)}>
               {t('competitions.participants.bulkInvite', 'Bulk Invite')}
@@ -419,6 +424,7 @@ export default function ParticipantsListPage() {
 
         {ConfirmDialogElement}
         {showBulkInvite && <BulkInviteDialog onClose={() => { setShowBulkInvite(false); queryClient.invalidateQueries({ queryKey: ['participations', 'competition-invitations-list'] }) }} />}
+        {showManualInvite && <ManualInviteDialog onClose={() => { setShowManualInvite(false); queryClient.invalidateQueries({ queryKey: ['participations', 'competition-invitations-list'] }) }} />}
       </PageBody>
     </Page>
   )

--- a/src/modules/competitions/components/ManualInviteDialog.tsx
+++ b/src/modules/competitions/components/ManualInviteDialog.tsx
@@ -1,0 +1,204 @@
+"use client"
+import * as React from 'react'
+import { Button } from '@open-mercato/ui/primitives/button'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { fetchCrudList } from '@open-mercato/ui/backend/utils/crud'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+import { useT } from '@open-mercato/shared/lib/i18n/context'
+
+type InviteResult = { email: string; status: 'sent' | 'skipped' | 'error'; reason?: string }
+
+const VALID_ROLES = ['participant', 'mentor', 'judge'] as const
+
+type Competition = { id: string; name: string }
+
+export function ManualInviteDialog({ onClose }: { onClose: () => void }) {
+  const t = useT()
+
+  // Competition selector
+  const [competitions, setCompetitions] = React.useState<Competition[]>([])
+  const [selectedCompetitionId, setSelectedCompetitionId] = React.useState('')
+
+  // Form fields
+  const [email, setEmail] = React.useState('')
+  const [displayName, setDisplayName] = React.useState('')
+  const [role, setRole] = React.useState<string>('participant')
+
+  // State
+  const [sending, setSending] = React.useState(false)
+  const [result, setResult] = React.useState<InviteResult | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  // Load competitions
+  React.useEffect(() => {
+    fetchCrudList<Competition>('competitions/competitions', { pageSize: '50' }).then(data => {
+      setCompetitions(data?.items ?? [])
+    })
+  }, [])
+
+  function validate(): string | null {
+    if (!selectedCompetitionId) return 'Please select a competition'
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) return 'Please enter a valid email address'
+    if (!displayName.trim()) return 'Please enter a display name'
+    return null
+  }
+
+  async function handleSend() {
+    const validationError = validate()
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    setError(null)
+    setSending(true)
+
+    const orgSlug = window.location.pathname.split('/')[1] || 'default'
+
+    const { ok, result: apiResult } = await apiCall<{
+      total: number; sent: number; skipped: number
+      errors: Array<{ email: string; reason: string }>
+      results: InviteResult[]
+    }>('/api/competitions/admin/bulk-invite', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        competition_id: selectedCompetitionId,
+        org_slug: orgSlug,
+        invitees: [{
+          email: email.trim().toLowerCase(),
+          display_name: displayName.trim(),
+          role,
+        }],
+      }),
+    })
+
+    setSending(false)
+
+    if (ok && apiResult?.results?.[0]) {
+      setResult(apiResult.results[0])
+    } else {
+      setResult({ email: email.trim(), status: 'error', reason: 'Request failed' })
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && !sending && !result) {
+      handleSend()
+    }
+    if (e.key === 'Escape') {
+      onClose()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="w-full max-w-md rounded-lg bg-background p-6 shadow-xl"
+        onClick={e => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-lg font-semibold">{t('competitions.manualInvite.title', 'Invite Participant')}</h3>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" x2="6" y1="6" y2="18" /><line x1="6" x2="18" y1="6" y2="18" /></svg>
+          </button>
+        </div>
+
+        {!result ? (
+          <div className="space-y-4">
+            {/* Competition */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">Competition</label>
+              <select
+                value={selectedCompetitionId}
+                onChange={(e) => setSelectedCompetitionId(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="">Select competition...</option>
+                {competitions.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
+              </select>
+            </div>
+
+            {/* Email */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="participant@example.com"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                autoFocus
+              />
+            </div>
+
+            {/* Display Name */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">Display Name</label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="John Doe"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+              />
+            </div>
+
+            {/* Role */}
+            <div>
+              <label className="mb-1 block text-sm font-medium">Role</label>
+              <select
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                {VALID_ROLES.map(r => (
+                  <option key={r} value={r}>{r.charAt(0).toUpperCase() + r.slice(1)}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <p className="text-sm text-portal-danger">{error}</p>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={onClose}>Cancel</Button>
+              <Button onClick={handleSend} disabled={sending}>
+                {sending ? 'Sending...' : 'Send Invitation'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {result.status === 'sent' ? (
+              <div className="rounded-lg bg-portal-success/10 p-4 text-center">
+                <p className="text-sm font-medium text-portal-success">Invitation sent to {result.email}</p>
+              </div>
+            ) : result.status === 'skipped' ? (
+              <div className="rounded-lg bg-amber-50 p-4 text-center">
+                <p className="text-sm font-medium text-amber-600">Skipped: {result.reason}</p>
+              </div>
+            ) : (
+              <div className="rounded-lg bg-portal-danger/10 p-4 text-center">
+                <p className="text-sm font-medium text-portal-danger">Error: {result.reason}</p>
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <Button onClick={() => {
+                onClose()
+                if (result.status === 'sent') flash(`Invitation sent to ${result.email}`, 'success')
+              }}>
+                Done
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a "Manual Invite" dialog in the backoffice participants page that lets admins invite a single participant by filling in email, display name, and role
- Uses the same bulk-invite API endpoint, so the full flow (user creation, invitation record, competition mapping, email sending) is identical to CSV bulk invite

## Test plan
- [ ] Open Backend → Competitions → Participants
- [ ] Click "Invite" button, fill in the form, and send
- [ ] Verify invitation appears in the Invitations tab
- [ ] Verify invitation email is received
- [ ] Compare behavior with Bulk Invite (should be identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)