### PR TITLE
Fix bounty hunting competition and org scoping

### DIFF
--- a/src/modules/bounties/api/activity/route.ts
+++ b/src/modules/bounties/api/activity/route.ts
@@ -29,27 +29,35 @@ export async function GET(request: Request) {
     })
 
     const em = container.resolve('em') as EntityManager
-    const activities = await em.find(
-      BountyActivityLog,
-      {
-        tenantId: auth.tenantId,
-        organizationId: auth.orgId,
-      },
-      {
-        orderBy: { createdAt: 'DESC' },
-        limit: parsed.limit,
-      }
-    )
+    const rows = await em.getConnection().execute(
+      `SELECT a.id, a.type, a.pull_request_id, a.actor_user_id, a.message, a.metadata, a.created_at
+       FROM bounties_activity_log a
+       LEFT JOIN bounties_pull_request pr ON pr.id = a.pull_request_id
+       WHERE a.tenant_id = ?
+         AND a.organization_id = ?
+         AND (?::uuid IS NULL OR pr.competition_id = ?::uuid)
+       ORDER BY a.created_at DESC
+       LIMIT ?`,
+      [auth.tenantId, auth.orgId, parsed.competition_id ?? null, parsed.competition_id ?? null, parsed.limit]
+    ) as Array<{
+      id: string
+      type: string
+      pull_request_id: string | null
+      actor_user_id: string | null
+      message: string
+      metadata: Record<string, unknown> | null
+      created_at: string | Date
+    }>
 
     return new Response(JSON.stringify({
-      items: activities.map(a => ({
+      items: rows.map((a) => ({
         id: a.id,
         type: a.type,
-        pull_request_id: a.pullRequestId,
-        actor_user_id: a.actorUserId,
+        pull_request_id: a.pull_request_id,
+        actor_user_id: a.actor_user_id,
         message: a.message,
         metadata: a.metadata,
-        created_at: a.createdAt,
+        created_at: a.created_at,
       })),
     }), {
       headers: { 'content-type': 'application/json' },

--- a/src/modules/bounties/api/portal/submit-pr/route.ts
+++ b/src/modules/bounties/api/portal/submit-pr/route.ts
@@ -39,6 +39,21 @@ export async function POST(req: Request) {
     const configService = container.resolve('moduleConfigService') as ModuleConfigService
     const eventBus = container.resolve('eventBus') as { emit: (id: string, payload: Record<string, unknown>) => Promise<void> }
 
+    const competition = await em.findOne(Competition, {
+      id: competitionId,
+      tenantId: auth.tenantId,
+      deletedAt: null,
+    } as FilterQuery<Competition>)
+    if (!competition) {
+      console.warn(LOG_PREFIX, `Rejected: competition=${competitionId} not found for tenant=${auth.tenantId}`)
+      return NextResponse.json({ error: 'Competition not found' }, { status: 404 })
+    }
+    if (auth.orgId && competition.organizationId !== auth.orgId) {
+      console.warn(LOG_PREFIX, `Rejected: org mismatch authOrg=${auth.orgId} competitionOrg=${competition.organizationId} competition=${competitionId}`)
+      return NextResponse.json({ error: 'Competition is not available in the current organization' }, { status: 403 })
+    }
+    const competitionOrganizationId = competition.organizationId
+
     // Verify this competition has a bounty track configured
     const mappings = await configService.getValue<Record<string, string>>('bounties', BOUNTY_TRACK_MAPPINGS_KEY, { defaultValue: {} })
     const bountyTrackId = mappings?.[competitionId]
@@ -53,6 +68,7 @@ export async function POST(req: Request) {
       customerUserId: auth.sub,
       competitionId,
       tenantId: auth.tenantId,
+      organizationId: competitionOrganizationId,
       deletedAt: null,
     } as FilterQuery<CompetitionParticipation>)
 
@@ -64,15 +80,27 @@ export async function POST(req: Request) {
 
     // Resolve team and verify participant is on the bounty track
     const teamMember = await em.getConnection().execute(
-      `SELECT tm.team_id FROM teams_team_member tm WHERE tm.customer_user_id = ? AND tm.competition_id = ? AND tm.tenant_id = ? AND tm.deleted_at IS NULL LIMIT 1`,
-      [participation.customerUserId, competitionId, auth.tenantId]
+      `SELECT tm.team_id
+       FROM teams_team_member tm
+       WHERE tm.customer_user_id = ?
+         AND tm.competition_id = ?
+         AND tm.tenant_id = ?
+         AND tm.organization_id = ?
+         AND tm.deleted_at IS NULL
+       LIMIT 1`,
+      [participation.customerUserId, competitionId, auth.tenantId, competitionOrganizationId]
     )
     const teamId = teamMember?.[0]?.team_id ?? null
 
     if (teamId) {
       const teamTracks = await em.getConnection().execute(
-        `SELECT track_id FROM teams_team_track WHERE team_id = ? AND competition_id = ? AND tenant_id = ?`,
-        [teamId, competitionId, auth.tenantId]
+        `SELECT track_id
+         FROM teams_team_track
+         WHERE team_id = ?
+           AND competition_id = ?
+           AND tenant_id = ?
+           AND organization_id = ?`,
+        [teamId, competitionId, auth.tenantId, competitionOrganizationId]
       )
       const trackIds = (teamTracks as Array<{ track_id: string }>).map(r => r.track_id)
       console.log(LOG_PREFIX, `Team=${teamId}, tracks=${JSON.stringify(trackIds)}, bountyTrack=${bountyTrackId}`)
@@ -103,22 +131,19 @@ export async function POST(req: Request) {
     console.log(LOG_PREFIX, `GitHub PR #${prNumber}: author=@${pr.user.login}, created_at=${pr.created_at}, title="${pr.title}"`)
 
     // Validate PR was created within the competition time window (date-only comparison to avoid timezone issues)
-    const competition = await em.findOne(Competition, { id: competitionId } as FilterQuery<Competition>)
-    if (competition) {
-      const prCreatedAt = new Date(pr.created_at)
-      const toDateOnly = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate())
-      const prDate = toDateOnly(prCreatedAt)
-      const startDate = toDateOnly(competition.startsAt)
-      const endDate = toDateOnly(competition.endsAt)
-      console.log(LOG_PREFIX, `Date check: prDate=${prDate.toISOString()}, startDate=${startDate.toISOString()}, endDate=${endDate.toISOString()} (raw: pr=${pr.created_at}, start=${competition.startsAt.toISOString()}, end=${competition.endsAt.toISOString()})`)
-      if (prDate < startDate) {
-        console.warn(LOG_PREFIX, `Rejected: PR created ${prDate.toISOString()} before competition start ${startDate.toISOString()}`)
-        return NextResponse.json({ error: `This PR was created before the competition started (${competition.startsAt.toLocaleDateString()})` }, { status: 400 })
-      }
-      if (prDate > endDate) {
-        console.warn(LOG_PREFIX, `Rejected: PR created ${prDate.toISOString()} after competition end ${endDate.toISOString()}`)
-        return NextResponse.json({ error: `This PR was created after the competition ended (${competition.endsAt.toLocaleDateString()})` }, { status: 400 })
-      }
+    const prCreatedAt = new Date(pr.created_at)
+    const toDateOnly = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate())
+    const prDate = toDateOnly(prCreatedAt)
+    const startDate = toDateOnly(competition.startsAt)
+    const endDate = toDateOnly(competition.endsAt)
+    console.log(LOG_PREFIX, `Date check: prDate=${prDate.toISOString()}, startDate=${startDate.toISOString()}, endDate=${endDate.toISOString()} (raw: pr=${pr.created_at}, start=${competition.startsAt.toISOString()}, end=${competition.endsAt.toISOString()})`)
+    if (prDate < startDate) {
+      console.warn(LOG_PREFIX, `Rejected: PR created ${prDate.toISOString()} before competition start ${startDate.toISOString()}`)
+      return NextResponse.json({ error: `This PR was created before the competition started (${competition.startsAt.toLocaleDateString()})` }, { status: 400 })
+    }
+    if (prDate > endDate) {
+      console.warn(LOG_PREFIX, `Rejected: PR created ${prDate.toISOString()} after competition end ${endDate.toISOString()}`)
+      return NextResponse.json({ error: `This PR was created after the competition ended (${competition.endsAt.toLocaleDateString()})` }, { status: 400 })
     }
 
     // Verify the PR belongs to the participant
@@ -161,7 +186,7 @@ export async function POST(req: Request) {
     // Create BountyPullRequest
     const bountyPR = em.create(BountyPullRequest, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId ?? '',
+      organizationId: competitionOrganizationId,
       competitionId,
       githubPrId: String(pr.id),
       githubPrNumber: pr.number,
@@ -183,7 +208,7 @@ export async function POST(req: Request) {
 
     const activity = em.create(BountyActivityLog, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId ?? '',
+      organizationId: competitionOrganizationId,
       type: BountyActivityType.PR_DETECTED,
       pullRequestId: bountyPR.id,
       message: `PR #${pr.number} submitted by participant @${pr.user.login}: "${pr.title}"`,
@@ -199,7 +224,7 @@ export async function POST(req: Request) {
     await eventBus.emit('bounties.pull_request.detected', {
       pullRequestId: bountyPR.id,
       tenantId: auth.tenantId,
-      organizationId: auth.orgId ?? '',
+      organizationId: competitionOrganizationId,
       competitionId,
     })
     console.log(LOG_PREFIX, `Event emitted: bounties.pull_request.detected for ${bountyPR.id}`)

--- a/src/modules/bounties/components/BountyActivityFeed.tsx
+++ b/src/modules/bounties/components/BountyActivityFeed.tsx
@@ -30,14 +30,16 @@ const typeIcons: Record<string, string> = {
   pr_split_ungrouped: '🔓',
 }
 
-export default function BountyActivityFeed() {
+export default function BountyActivityFeed({ competitionId = null }: { competitionId?: string | null }) {
   const t = useT()
   const scopeVersion = useOrganizationScopeVersion()
 
   const { data, isLoading } = useQuery({
-    queryKey: ['bounty-activity', scopeVersion],
+    queryKey: ['bounty-activity', competitionId, scopeVersion],
     queryFn: async () => {
-      const res = await apiCall('/api/bounties/activity?limit=20')
+      const params = new URLSearchParams({ limit: '20' })
+      if (competitionId) params.set('competition_id', competitionId)
+      const res = await apiCall(`/api/bounties/activity?${params.toString()}`)
       return res as unknown as { items: ActivityItem[] }
     },
     refetchInterval: 5000,

--- a/src/modules/bounties/components/BountyJudgingPanel.tsx
+++ b/src/modules/bounties/components/BountyJudgingPanel.tsx
@@ -39,6 +39,12 @@ type BountyPRRow = {
   _team?: { name: string | null }
 }
 
+type CompetitionOption = {
+  id: string
+  name: string
+  stage?: string | null
+}
+
 const statusPreset: Record<string, { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline' }> = {
   detected: { label: 'Detected', variant: 'secondary' },
   classified: { label: 'Classified', variant: 'outline' },
@@ -56,6 +62,7 @@ export default function BountyJudgingPanel() {
   const scopeVersion = useOrganizationScopeVersion()
   const [page, setPage] = React.useState(1)
   const [statusFilter, setStatusFilter] = React.useState<string>('all')
+  const [competitionFilter, setCompetitionFilter] = React.useState<string>('all')
   const [selectedPRId, setSelectedPRId] = React.useState<string | null>(null)
 
   // Real-time updates
@@ -63,6 +70,35 @@ export default function BountyJudgingPanel() {
     queryClient.invalidateQueries({ queryKey: ['bounty-prs'] })
     queryClient.invalidateQueries({ queryKey: ['bounty-activity'] })
   }, [queryClient])
+
+  const { data: competitions, isLoading: competitionsLoading } = useQuery({
+    queryKey: ['bounty-competitions', scopeVersion],
+    queryFn: async () => {
+      const res = await fetchCrudList<CompetitionOption>('competitions/competitions', {
+        pageSize: '100',
+        sortField: 'created_at',
+        sortDir: 'desc',
+      })
+      return res?.items ?? []
+    },
+  })
+
+  React.useEffect(() => {
+    if (!competitions || competitions.length === 0) return
+    const stored = window.localStorage.getItem('bounties:selected-competition')
+    if (stored && competitions.some((competition) => competition.id === stored)) {
+      setCompetitionFilter(stored)
+      return
+    }
+    setCompetitionFilter((current) => {
+      if (current !== 'all' && competitions.some((competition) => competition.id === current)) {
+        return current
+      }
+      const next = competitions[0]?.id ?? 'all'
+      if (next !== 'all') window.localStorage.setItem('bounties:selected-competition', next)
+      return next
+    })
+  }, [competitions])
 
   const queryParams = React.useMemo(() => {
     const params: Record<string, string> = {
@@ -72,13 +108,20 @@ export default function BountyJudgingPanel() {
       sortDir: 'desc',
     }
     if (statusFilter !== 'all') params.status = statusFilter
+    if (competitionFilter !== 'all') params.competition_id = competitionFilter
     return params
-  }, [page, statusFilter])
+  }, [competitionFilter, page, statusFilter])
 
   const { data, isLoading } = useQuery({
     queryKey: ['bounty-prs', queryParams, scopeVersion],
     queryFn: () => fetchCrudList<BountyPRRow>('bounties/prs', queryParams),
   })
+
+  React.useEffect(() => {
+    if (!data?.items?.some(pr => pr.id === selectedPRId)) {
+      setSelectedPRId(null)
+    }
+  }, [data, selectedPRId])
 
   const selectedPR = React.useMemo(
     () => data?.items?.find(pr => pr.id === selectedPRId) ?? null,
@@ -179,6 +222,24 @@ export default function BountyJudgingPanel() {
 
       {/* Status filter tabs */}
       <div className="flex items-center gap-2 flex-wrap">
+        <select
+          value={competitionFilter}
+          onChange={(e) => {
+            const next = e.target.value
+            setCompetitionFilter(next)
+            setPage(1)
+            window.localStorage.setItem('bounties:selected-competition', next)
+          }}
+          className="h-9 min-w-[220px] rounded-md border border-input bg-background px-3 text-sm"
+          disabled={competitionsLoading}
+        >
+          <option value="all">{t('bounties.filter.allCompetitions', 'All competitions')}</option>
+          {(competitions ?? []).map((competition) => (
+            <option key={competition.id} value={competition.id}>
+              {competition.name}
+            </option>
+          ))}
+        </select>
         {STATUS_TABS.map(tab => (
           <Button
             key={tab}
@@ -237,7 +298,7 @@ export default function BountyJudgingPanel() {
       </div>
 
       {/* Activity feed */}
-      <BountyActivityFeed />
+      <BountyActivityFeed competitionId={competitionFilter !== 'all' ? competitionFilter : null} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a competition filter to the bounty hunting backoffice panel and scope the activity feed to the selected competition
- fix portal PR submission so bounty PRs are stored under the competition organization instead of the ambient auth org
- tighten participation, team membership, and track lookups to the competition organization

## Root cause
The bounty admin list API already supported the competition_id filter, but the backoffice UI never sent it, so the panel always mixed all competitions inside the selected org scope. Separately, the portal submit flow validated against a competition but persisted organizationId from the current auth context, which allowed PRs to be stored under the wrong organization and appear only under All organizations.

## Verification
- yarn typecheck
