### PR TITLE
Fix track attachment download for portal users

### DIFF
--- a/src/modules/tracks/api/portal/attachment-file/[id]/route.ts
+++ b/src/modules/tracks/api/portal/attachment-file/[id]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'fs'
+import { getCustomerAuthFromRequest } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { Attachment } from '@open-mercato/core/modules/attachments/data/entities'
+import { resolveAttachmentAbsolutePath } from '@open-mercato/core/modules/attachments/lib/storage'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+export const metadata = {
+  GET: { requireCustomerAuth: true },
+}
+
+export async function GET(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params
+  if (!id) {
+    return NextResponse.json({ error: 'Attachment id is required' }, { status: 400 })
+  }
+
+  const auth = await getCustomerAuthFromRequest(req)
+  if (!auth?.sub) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  const { resolve } = await createRequestContainer()
+  const em = resolve('em') as EntityManager
+
+  const attachment = await em.findOne(Attachment, { id })
+  if (!attachment) {
+    return NextResponse.json({ error: 'Attachment not found' }, { status: 404 })
+  }
+
+  // Scope check: attachment must belong to the same org
+  if (attachment.organizationId && attachment.organizationId !== auth.orgId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  // Scope check: attachment must belong to the tracks entity
+  if (attachment.entityId !== 'tracks:track') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const filePath = resolveAttachmentAbsolutePath(
+    attachment.partitionCode,
+    attachment.storagePath,
+    attachment.storageDriver,
+  )
+
+  let buffer: Buffer
+  try {
+    buffer = await fs.readFile(filePath)
+  } catch {
+    return NextResponse.json({ error: 'File not available' }, { status: 404 })
+  }
+
+  const url = new URL(req.url)
+  const forceDownload = url.searchParams.get('download') === '1'
+  const headers: Record<string, string> = {
+    'Content-Type': attachment.mimeType || 'application/octet-stream',
+    'Cache-Control': 'private, max-age=3600',
+  }
+  if (attachment.fileSize > 0) {
+    headers['Content-Length'] = String(attachment.fileSize)
+  }
+  if (forceDownload) {
+    headers['Content-Disposition'] = `attachment; filename="${encodeURIComponent(attachment.fileName)}"`
+  }
+
+  return new NextResponse(new Uint8Array(buffer), { status: 200, headers })
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Portal',
+  summary: 'Serve track attachment file (portal)',
+  methods: {
+    GET: { summary: 'Download or serve a track attachment file for portal users' },
+  },
+}

--- a/src/modules/tracks/api/portal/track-detail/route.ts
+++ b/src/modules/tracks/api/portal/track-detail/route.ts
@@ -53,7 +53,11 @@ export async function GET(req: Request) {
         `SELECT id, file_name, file_size, url, mime_type FROM attachments WHERE entity_id = 'tracks:track' AND record_id = ? ORDER BY created_at`,
         [trackId],
       )
-      attachments = rawAttachments as typeof attachments
+      // Rewrite URLs to use the portal endpoint (core endpoint requires backend auth)
+      attachments = (rawAttachments as typeof attachments).map(att => ({
+        ...att,
+        url: `/api/tracks/portal/attachment-file/${att.id}`,
+      }))
     } catch {
       // Attachments module may not be available — continue without
     }


### PR DESCRIPTION
## Summary
- Portal users got 401 errors when downloading track attachments because the download URL pointed to the core `/api/attachments/file/` endpoint, which requires backend admin auth
- Added a portal-specific attachment file endpoint (`/api/tracks/portal/attachment-file/[id]`) that uses customer auth instead
- Rewrote attachment URLs in the track-detail API response to use the new portal endpoint

## Test plan
- [ ] Log in as a portal user (not backend admin)
- [ ] Open a track detail page that has attachments
- [ ] Click download on an attachment — should download successfully
- [ ] Verify backend admin download still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)