### PR TITLE
Fix bounty judge access and approval scope

### DIFF
--- a/src/modules/bounties/api/portal/judge/access/route.ts
+++ b/src/modules/bounties/api/portal/judge/access/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { getCustomerAuthFromRequest } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { ModuleConfigService } from '@open-mercato/core/modules/configs/lib/module-config-service'
+import { z } from 'zod'
+import { verifyBountyJudge } from '../../../../lib/portalJudgeAuth'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const querySchema = z.object({
+  competitionId: z.string().uuid(),
+})
+
+export const metadata = {
+  GET: {
+    requireCustomerAuth: true,
+    requireCustomerFeatures: ['portal.bounties.judge'],
+  },
+}
+
+export async function GET(req: Request) {
+  try {
+    const auth = await getCustomerAuthFromRequest(req)
+    if (!auth?.sub) return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+
+    const url = new URL(req.url)
+    const parsed = querySchema.parse({
+      competitionId: url.searchParams.get('competitionId') ?? undefined,
+    })
+
+    const container = await createRequestContainer()
+    const em = container.resolve('em') as EntityManager
+    const configService = container.resolve('moduleConfigService') as ModuleConfigService
+
+    const judgeInfo = await verifyBountyJudge(em, auth, configService, parsed.competitionId)
+
+    return NextResponse.json({
+      canAccess: Boolean(judgeInfo),
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Validation failed', details: error.issues }, { status: 422 })
+    }
+    console.error('[bounties/portal/judge/access] GET error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Bounties Portal',
+  summary: 'Check portal bounty judge access',
+  methods: { GET: { summary: 'Check whether the current portal user can access the bounty judge panel for a competition' } },
+}

--- a/src/modules/bounties/api/prs/[id]/approve/route.ts
+++ b/src/modules/bounties/api/prs/[id]/approve/route.ts
@@ -1,5 +1,6 @@
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog, BOUNTY_POINTS } from '../../../../data/entities'
 import type { BountyClassification } from '../../../../data/entities'
@@ -9,10 +10,10 @@ export const metadata = {
   PATCH: { requireAuth: true, requireFeatures: ['bounties.judge'] },
 }
 
-export async function PATCH(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   try {
     const container = await createRequestContainer()
-    const auth = await getAuthFromCookies()
+    const auth = await getAuthFromRequest(request)
     if (!auth?.tenantId) {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'content-type': 'application/json' } })
     }
@@ -20,13 +21,19 @@ export async function PATCH(_request: Request, { params }: { params: Promise<{ i
     const { id } = await params
     const em = container.resolve('em') as EntityManager
     const eventBus = container.resolve('eventBus') as { emit: (id: string, payload: Record<string, unknown>) => Promise<void> }
+    const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
+    const scopeOrganizationId = scope.selectedId ?? auth.orgId ?? null
 
-    const pr = await em.findOne(BountyPullRequest, {
+    const filters: FilterQuery<BountyPullRequest> = {
       id,
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
       deletedAt: null,
-    } as FilterQuery<BountyPullRequest>)
+    }
+    if (scopeOrganizationId) {
+      filters.organizationId = scopeOrganizationId
+    }
+
+    const pr = await em.findOne(BountyPullRequest, filters)
 
     if (!pr) {
       return new Response(JSON.stringify({ error: 'PR not found' }), { status: 404, headers: { 'content-type': 'application/json' } })

--- a/src/modules/bounties/components/BountyDetailPanel.tsx
+++ b/src/modules/bounties/components/BountyDetailPanel.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { EnumBadge } from '@open-mercato/ui/backend/ValueIcons'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
@@ -56,7 +56,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
 
   const handleApprove = async () => {
     try {
-      await apiCall(`/api/bounties/prs/${pr.id}/approve`, { method: 'PATCH', body: '{}' })
+      await apiCallOrThrow(`/api/bounties/prs/${pr.id}/approve`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.approved', 'PR approved'), 'success')
       onAction()
     } catch (err) {
@@ -66,7 +66,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
 
   const handleReject = async () => {
     try {
-      await apiCall(`/api/bounties/prs/${pr.id}/reject`, { method: 'PATCH', body: '{}' })
+      await apiCallOrThrow(`/api/bounties/prs/${pr.id}/reject`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.rejected', 'PR rejected'), 'success')
       onAction()
     } catch (err) {
@@ -78,7 +78,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
     const pts = parseInt(adjustPoints, 10)
     if (isNaN(pts) || pts < 0 || !adjustReason.trim()) return
     try {
-      await apiCall(`/api/bounties/prs/${pr.id}/points`, {
+      await apiCallOrThrow(`/api/bounties/prs/${pr.id}/points`, {
         method: 'PATCH',
         body: JSON.stringify({ total_points: pts, reason: adjustReason }),
       })
@@ -181,7 +181,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
                 size="sm"
                 onClick={async () => {
                   try {
-                    await apiCall(`/api/bounties/splits/${pr.split_group_id}/ungroup`, { method: 'POST', body: '{}' })
+                    await apiCallOrThrow(`/api/bounties/splits/${pr.split_group_id}/ungroup`, { method: 'POST', body: '{}' })
                     flash(t('bounties.flash.ungrouped', 'Split group removed — individual scoring restored'), 'success')
                     onAction()
                   } catch {

--- a/src/modules/bounties/components/BountyJudgingPanel.tsx
+++ b/src/modules/bounties/components/BountyJudgingPanel.tsx
@@ -7,7 +7,7 @@ import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { EnumBadge } from '@open-mercato/ui/backend/ValueIcons'
 import { fetchCrudList } from '@open-mercato/ui/backend/utils/crud'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
@@ -130,7 +130,7 @@ export default function BountyJudgingPanel() {
 
   const handleApprove = React.useCallback(async (id: string) => {
     try {
-      await apiCall(`/api/bounties/prs/${id}/approve`, { method: 'PATCH', body: '{}' })
+      await apiCallOrThrow(`/api/bounties/prs/${id}/approve`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.approved', 'PR approved'), 'success')
       queryClient.invalidateQueries({ queryKey: ['bounty-prs'] })
     } catch (err) {
@@ -140,7 +140,7 @@ export default function BountyJudgingPanel() {
 
   const handleReject = React.useCallback(async (id: string) => {
     try {
-      await apiCall(`/api/bounties/prs/${id}/reject`, { method: 'PATCH', body: '{}' })
+      await apiCallOrThrow(`/api/bounties/prs/${id}/reject`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.rejected', 'PR rejected'), 'success')
       queryClient.invalidateQueries({ queryKey: ['bounty-prs'] })
     } catch (err) {

--- a/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.meta.ts
+++ b/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.meta.ts
@@ -1,0 +1,4 @@
+export const metadata = {
+  requireCustomerAuth: true,
+  requireCustomerFeatures: ['portal.bounties.judge'],
+}

--- a/src/modules/bounties/lib/portalJudgeAuth.ts
+++ b/src/modules/bounties/lib/portalJudgeAuth.ts
@@ -10,6 +10,11 @@ type PortalAuth = {
   orgId: string
 }
 
+type BountyJudgeInfo = {
+  bountyTrackIds: string[]
+  panelIds: string[]
+}
+
 /**
  * Verify that a portal-authenticated user is a judge on a panel
  * assigned to the bounty track for at least one competition.
@@ -19,7 +24,8 @@ export async function verifyBountyJudge(
   em: EntityManager,
   auth: PortalAuth,
   configService: ModuleConfigService,
-): Promise<{ bountyTrackIds: string[]; panelIds: string[] } | null> {
+  competitionId?: string | null,
+): Promise<BountyJudgeInfo | null> {
   // 1. Get bounty track mappings (competition_id -> track_id)
   const mappings = await configService.getValue<Record<string, string>>(
     'bounties',
@@ -28,7 +34,10 @@ export async function verifyBountyJudge(
   )
   if (!mappings || Object.keys(mappings).length === 0) return null
 
-  const bountyTrackIds = Object.values(mappings)
+  const bountyTrackIds = competitionId
+    ? [mappings[competitionId]].filter((trackId): trackId is string => Boolean(trackId))
+    : Object.values(mappings)
+  if (bountyTrackIds.length === 0) return null
 
   // 2. Find judge panels this user is on
   const panelJudges = await em.find(JudgePanelJudge, {


### PR DESCRIPTION
## Summary
- add competition-aware bounty judge access checks for the portal judge panel
- fix backoffice bounty approval to respect selected organization scope
- surface failed backoffice approve/reject actions instead of silently treating them as success

## Additional fixes
- fix bounty judge participant lookups to use 
- replace malformed Postgres  array queries with safe  lookups
- restore portal judge route metadata required by generated module imports

## Verification
- yarn generate
- yarn typecheck