### PR TITLE
Fix bounty panel cache invalidation

### DIFF
--- a/src/modules/bounties/api/portal/judge/prs/[id]/approve/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/approve/route.ts
@@ -7,6 +7,7 @@ import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLo
 import type { BountyClassification } from '../../../../../../data/entities'
 import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
 
 export const metadata = {
   PATCH: { requireCustomerAuth: true },
@@ -53,6 +54,11 @@ export async function PATCH(_request: Request, { params }: { params: Promise<{ i
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.approve')
 
     await eventBus.emit('bounties.pull_request.approved', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/portal/judge/prs/[id]/classify/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/classify/route.ts
@@ -9,6 +9,7 @@ import type { BountyCategory, BountyClassification } from '../../../../../../dat
 import { bountyCategoryValues } from '../../../../../../data/validators'
 import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
 
 const overrideSchema = z.object({
   classifications: z.array(z.object({
@@ -69,6 +70,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.classify')
 
     await eventBus.emit('bounties.pull_request.points_adjusted', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/portal/judge/prs/[id]/duplicate/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/duplicate/route.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../../../data/entities'
 import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
 
 const markDuplicateSchema = z.object({
   duplicate_of_id: z.string().uuid(),
@@ -70,6 +71,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.duplicate')
 
     await eventBus.emit('bounties.pull_request.duplicate_detected', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/portal/judge/prs/[id]/points/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/points/route.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { BountyPullRequest, BountyActivityType, BountyActivityLog } from '../../../../../../data/entities'
 import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
 
 const adjustPointsSchema = z.object({
   total_points: z.number().int().min(0),
@@ -59,6 +60,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.points')
 
     await eventBus.emit('bounties.pull_request.points_adjusted', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/portal/judge/prs/[id]/reject/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/reject/route.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../../../data/entities'
 import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
 
 const rejectSchema = z.object({
   reason: z.string().optional(),
@@ -58,6 +59,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.reject')
 
     await eventBus.emit('bounties.pull_request.rejected', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/prs/[id]/approve/route.ts
+++ b/src/modules/bounties/api/prs/[id]/approve/route.ts
@@ -5,6 +5,7 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog, BOUNTY_POINTS } from '../../../../data/entities'
 import type { BountyClassification } from '../../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
 
 export const metadata = {
   PATCH: { requireAuth: true, requireFeatures: ['bounties.judge'] },
@@ -57,6 +58,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.approve')
 
     await eventBus.emit('bounties.pull_request.approved', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/prs/[id]/classify/route.ts
+++ b/src/modules/bounties/api/prs/[id]/classify/route.ts
@@ -6,6 +6,7 @@ import { BountyPullRequest, BountyActivityType, BountyActivityLog, BOUNTY_POINTS
 import type { BountyCategory, BountyClassification } from '../../../../data/entities'
 import { bountyCategoryValues } from '../../../../data/validators'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
 
 const overrideSchema = z.object({
   classifications: z.array(z.object({
@@ -65,6 +66,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.classify')
 
     await eventBus.emit('bounties.pull_request.points_adjusted', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/prs/[id]/duplicate/route.ts
+++ b/src/modules/bounties/api/prs/[id]/duplicate/route.ts
@@ -4,6 +4,7 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { z } from 'zod'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
 
 const markDuplicateSchema = z.object({
   duplicate_of_id: z.string().uuid(),
@@ -69,6 +70,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.duplicate')
 
     await eventBus.emit('bounties.pull_request.duplicate_detected', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/prs/[id]/points/route.ts
+++ b/src/modules/bounties/api/prs/[id]/points/route.ts
@@ -4,6 +4,7 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { z } from 'zod'
 import { BountyPullRequest, BountyActivityType, BountyActivityLog } from '../../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
 
 const adjustPointsSchema = z.object({
   total_points: z.number().int().min(0),
@@ -55,6 +56,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.points')
 
     await eventBus.emit('bounties.pull_request.points_adjusted', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/api/prs/[id]/reject/route.ts
+++ b/src/modules/bounties/api/prs/[id]/reject/route.ts
@@ -4,6 +4,7 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { z } from 'zod'
 import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
 
 const rejectSchema = z.object({
   reason: z.string().optional(),
@@ -54,6 +55,11 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 
     em.persist([pr, activity])
     await em.flush()
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.reject')
 
     await eventBus.emit('bounties.pull_request.rejected', {
       pullRequestId: pr.id,

--- a/src/modules/bounties/components/BountyJudgingPanel.tsx
+++ b/src/modules/bounties/components/BountyJudgingPanel.tsx
@@ -90,14 +90,12 @@ export default function BountyJudgingPanel() {
       setCompetitionFilter(stored)
       return
     }
-    setCompetitionFilter((current) => {
-      if (current !== 'all' && competitions.some((competition) => competition.id === current)) {
-        return current
-      }
-      const next = competitions[0]?.id ?? 'all'
-      if (next !== 'all') window.localStorage.setItem('bounties:selected-competition', next)
-      return next
-    })
+    setCompetitionFilter((current) => (
+      current !== 'all' && competitions.some((competition) => competition.id === current)
+        ? current
+        : 'all'
+    ))
+    window.localStorage.removeItem('bounties:selected-competition')
   }, [competitions])
 
   const queryParams = React.useMemo(() => {

--- a/src/modules/bounties/lib/cache.ts
+++ b/src/modules/bounties/lib/cache.ts
@@ -1,0 +1,25 @@
+import type { AwilixContainer } from 'awilix'
+import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
+
+type BountyCacheIdentifiers = {
+  id?: string | null
+  organizationId?: string | null
+  tenantId?: string | null
+}
+
+const BOUNTY_PR_CACHE_ALIASES = ['bounties.prs']
+
+export async function invalidateBountyPrCache(
+  container: AwilixContainer,
+  identifiers: BountyCacheIdentifiers,
+  reason: string,
+): Promise<void> {
+  await invalidateCrudCache(
+    container,
+    'BountyPullRequest',
+    identifiers,
+    identifiers.tenantId ?? null,
+    reason,
+    BOUNTY_PR_CACHE_ALIASES,
+  )
+}


### PR DESCRIPTION
## Summary
- invalidate cached bounty PR list responses after approve, reject, duplicate, classify, and points updates
- apply the same cache invalidation to portal judge mutation routes
- keep the backoffice bounty panel on All competitions by default instead of silently narrowing to the first competition

## Why
Production can serve stale cached GET responses for different status tabs independently. That allows the same PR to appear under conflicting tabs until cache expires.

## Verification
- yarn generate
- yarn typecheck