### PR TITLE
Add manual AI rerun action for bounty judging

### DIFF
--- a/src/modules/bounties/api/portal/judge/prs/[id]/rerun-ai/route.ts
+++ b/src/modules/bounties/api/portal/judge/prs/[id]/rerun-ai/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server'
+import { createQueue } from '@open-mercato/queue'
+import { getCustomerAuthFromRequest } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import type { ModuleConfigService } from '@open-mercato/core/modules/configs/lib/module-config-service'
+import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../../../data/entities'
+import { verifyBountyJudge } from '../../../../../../lib/portalJudgeAuth'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../../../lib/cache'
+
+export const metadata = {
+  PATCH: { requireCustomerAuth: true },
+}
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const auth = await getCustomerAuthFromRequest(request)
+    if (!auth?.sub) return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+
+    const container = await createRequestContainer()
+    const em = container.resolve('em') as EntityManager
+    const configService = container.resolve('moduleConfigService') as ModuleConfigService
+
+    const judgeInfo = await verifyBountyJudge(em, auth, configService)
+    if (!judgeInfo) return NextResponse.json({ error: 'Not a bounty judge' }, { status: 403 })
+
+    const { id } = await params
+    const pr = await em.findOne(BountyPullRequest, {
+      id,
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+      deletedAt: null,
+    } as FilterQuery<BountyPullRequest>)
+
+    if (!pr) return NextResponse.json({ error: 'PR not found' }, { status: 404 })
+
+    if (pr.status !== BountyPRStatus.DETECTED) {
+      return NextResponse.json({ error: 'AI check can only be rerun for PRs in Detected state' }, { status: 409 })
+    }
+
+    const activity = em.create(BountyActivityLog, {
+      tenantId: pr.tenantId,
+      organizationId: pr.organizationId,
+      type: BountyActivityType.MANUAL_REFRESH,
+      pullRequestId: pr.id,
+      actorUserId: auth.sub,
+      message: `PR #${pr.githubPrNumber} queued for manual AI classification`,
+      metadata: { source: 'portal_judge_panel' },
+      createdAt: new Date(),
+    })
+
+    em.persist(activity)
+    await em.flush()
+
+    const queue = createQueue('bounties-queue', 'local')
+    await queue.enqueue({
+      workerId: 'classify-pr',
+      pullRequestId: pr.id,
+      tenantId: pr.tenantId,
+      organizationId: pr.organizationId,
+    })
+
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.portal.pr.rerun-ai')
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('[bounties/portal/judge/rerun-ai] PATCH error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Bounties Portal',
+  summary: 'Queue manual AI classification for a detected bounty PR (portal judge)',
+  methods: { PATCH: { summary: 'Rerun AI classification for a detected bounty PR as a portal judge' } },
+}

--- a/src/modules/bounties/api/prs/[id]/rerun-ai/route.ts
+++ b/src/modules/bounties/api/prs/[id]/rerun-ai/route.ts
@@ -1,0 +1,89 @@
+import { createQueue } from '@open-mercato/queue'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import { BountyPullRequest, BountyPRStatus, BountyActivityType, BountyActivityLog } from '../../../../data/entities'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { invalidateBountyPrCache } from '../../../../lib/cache'
+
+export const metadata = {
+  PATCH: { requireAuth: true, requireFeatures: ['bounties.judge'] },
+}
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const container = await createRequestContainer()
+    const auth = await getAuthFromRequest(request)
+    if (!auth?.tenantId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'content-type': 'application/json' } })
+    }
+
+    const { id } = await params
+    const em = container.resolve('em') as EntityManager
+    const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
+    const scopeOrganizationId = scope.selectedId ?? auth.orgId ?? null
+
+    const filters: FilterQuery<BountyPullRequest> = {
+      id,
+      tenantId: auth.tenantId,
+      deletedAt: null,
+    }
+    if (scopeOrganizationId) {
+      filters.organizationId = scopeOrganizationId
+    }
+
+    const pr = await em.findOne(BountyPullRequest, filters)
+    if (!pr) {
+      return new Response(JSON.stringify({ error: 'PR not found' }), { status: 404, headers: { 'content-type': 'application/json' } })
+    }
+
+    if (pr.status !== BountyPRStatus.DETECTED) {
+      return new Response(JSON.stringify({ error: 'AI check can only be rerun for PRs in Detected state' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    const activity = em.create(BountyActivityLog, {
+      tenantId: pr.tenantId,
+      organizationId: pr.organizationId,
+      type: BountyActivityType.MANUAL_REFRESH,
+      pullRequestId: pr.id,
+      actorUserId: auth.userId ?? auth.sub ?? null,
+      message: `PR #${pr.githubPrNumber} queued for manual AI classification`,
+      metadata: { source: 'backend_judge_panel' },
+      createdAt: new Date(),
+    })
+
+    em.persist(activity)
+    await em.flush()
+
+    const queue = createQueue('bounties-queue', 'local')
+    await queue.enqueue({
+      workerId: 'classify-pr',
+      pullRequestId: pr.id,
+      tenantId: pr.tenantId,
+      organizationId: pr.organizationId,
+    })
+
+    await invalidateBountyPrCache(container, {
+      id: pr.id,
+      organizationId: pr.organizationId,
+      tenantId: pr.tenantId,
+    }, 'bounties.pr.rerun-ai')
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'content-type': 'application/json' },
+    })
+  } catch (error) {
+    console.error('[bounties/rerun-ai] PATCH error:', error)
+    return new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500, headers: { 'content-type': 'application/json' } })
+  }
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Bounties',
+  summary: 'Queue manual AI classification for a detected bounty PR',
+  methods: { PATCH: { summary: 'Rerun AI classification for a detected bounty PR' } },
+}

--- a/src/modules/bounties/components/BountyDetailPanel.tsx
+++ b/src/modules/bounties/components/BountyDetailPanel.tsx
@@ -51,26 +51,46 @@ interface Props {
 
 export default function BountyDetailPanel({ pr, onAction }: Props) {
   const t = useT()
+  const [actionLoading, setActionLoading] = React.useState<string | null>(null)
   const [adjustPoints, setAdjustPoints] = React.useState('')
   const [adjustReason, setAdjustReason] = React.useState('')
 
   const handleApprove = async () => {
     try {
+      setActionLoading('approve')
       await apiCallOrThrow(`/api/bounties/prs/${pr.id}/approve`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.approved', 'PR approved'), 'success')
       onAction()
     } catch (err) {
       flash(err instanceof Error ? err.message : 'Failed', 'error')
+    } finally {
+      setActionLoading(null)
     }
   }
 
   const handleReject = async () => {
     try {
+      setActionLoading('reject')
       await apiCallOrThrow(`/api/bounties/prs/${pr.id}/reject`, { method: 'PATCH', body: '{}' })
       flash(t('bounties.flash.rejected', 'PR rejected'), 'success')
       onAction()
     } catch (err) {
       flash(err instanceof Error ? err.message : 'Failed', 'error')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  const handleRerunAiCheck = async () => {
+    try {
+      setActionLoading('rerun-ai')
+      await apiCallOrThrow(`/api/bounties/prs/${pr.id}/rerun-ai`, { method: 'PATCH', body: '{}' })
+      flash(t('bounties.flash.aiCheckQueued', 'AI classification queued'), 'success')
+      onAction()
+    } catch (err) {
+      flash(err instanceof Error ? err.message : 'Failed', 'error')
+    } finally {
+      setActionLoading(null)
     }
   }
 
@@ -78,6 +98,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
     const pts = parseInt(adjustPoints, 10)
     if (isNaN(pts) || pts < 0 || !adjustReason.trim()) return
     try {
+      setActionLoading('points')
       await apiCallOrThrow(`/api/bounties/prs/${pr.id}/points`, {
         method: 'PATCH',
         body: JSON.stringify({ total_points: pts, reason: adjustReason }),
@@ -88,6 +109,8 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
       onAction()
     } catch (err) {
       flash(err instanceof Error ? err.message : 'Failed', 'error')
+    } finally {
+      setActionLoading(null)
     }
   }
 
@@ -196,20 +219,30 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
         </div>
       )}
 
+      {pr.status === 'detected' && (
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={handleRerunAiCheck} disabled={actionLoading !== null}>
+            {actionLoading === 'rerun-ai'
+              ? t('bounties.actions.runningAiCheck', 'Running AI Check...')
+              : t('bounties.actions.runAiCheck', 'Run AI Check')}
+          </Button>
+        </div>
+      )}
+
       {/* Actions */}
       {(pr.status === 'pending_review' || pr.status === 'classified') && (
         <div className="flex gap-2">
-          <Button variant="default" size="sm" onClick={handleApprove}>
+          <Button variant="default" size="sm" onClick={handleApprove} disabled={actionLoading !== null}>
             {t('bounties.actions.approve', 'Approve')}
           </Button>
-          <Button variant="destructive" size="sm" onClick={handleReject}>
+          <Button variant="destructive" size="sm" onClick={handleReject} disabled={actionLoading !== null}>
             {t('bounties.actions.reject', 'Reject')}
           </Button>
         </div>
       )}
 
       {pr.status === 'rejected' && (
-        <Button variant="default" size="sm" onClick={handleApprove}>
+        <Button variant="default" size="sm" onClick={handleApprove} disabled={actionLoading !== null}>
           {t('bounties.actions.approveInstead', 'Approve Instead')}
         </Button>
       )}
@@ -234,7 +267,7 @@ export default function BountyDetailPanel({ pr, onAction }: Props) {
               placeholder="Reason"
               className="flex-1 rounded border px-2 py-1 text-sm"
             />
-            <Button variant="outline" size="sm" onClick={handleAdjustPoints} disabled={!adjustPoints || !adjustReason.trim()}>
+            <Button variant="outline" size="sm" onClick={handleAdjustPoints} disabled={actionLoading !== null || !adjustPoints || !adjustReason.trim()}>
               {t('bounties.actions.adjust', 'Adjust')}
             </Button>
           </div>

--- a/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.tsx
+++ b/src/modules/bounties/frontend/[orgSlug]/portal/bounties/judge/page.tsx
@@ -10,7 +10,7 @@ import { PortalCompetitionLayout } from '../../../../../../competitions/componen
 import { PortalPageTitle, SectionLabel, PortalBadge, CompetitionCountdown } from '@/components/portal'
 import {
   GitPullRequest, CheckCircle, XCircle, AlertTriangle, ExternalLink,
-  ChevronLeft, Clock, Shield, Copy, Pencil, Trophy, Loader2,
+  ChevronLeft, Clock, Shield, Copy, Pencil, Trophy, Loader2, RefreshCw,
 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -411,6 +411,7 @@ function PRDetailPanel({ pr, onAction, onBack }: { pr: BountyPR; onAction: () =>
 
   const handleApprove = () => doAction(`/api/bounties/portal/judge/prs/${pr.id}/approve`)
   const handleReject = () => doAction(`/api/bounties/portal/judge/prs/${pr.id}/reject`)
+  const handleRerunAiCheck = () => doAction(`/api/bounties/portal/judge/prs/${pr.id}/rerun-ai`)
 
   const handleAdjustPoints = () => {
     const pts = parseInt(adjustPoints, 10)
@@ -469,7 +470,7 @@ function PRDetailPanel({ pr, onAction, onBack }: { pr: BountyPR; onAction: () =>
           </div>
           <div className="shrink-0 flex flex-col items-center rounded-lg bg-portal-primary/5 px-3 py-2">
             <span className="text-2xl font-bold text-portal-primary">
-              {(pr.points_override ?? pr.classifications ?? []).reduce((sum, c) => sum + c.points, 0)}
+              {pr.total_points}
             </span>
             <span className="text-[9px] font-semibold uppercase tracking-wider text-portal-secondary">pts</span>
           </div>
@@ -547,6 +548,24 @@ function PRDetailPanel({ pr, onAction, onBack }: { pr: BountyPR; onAction: () =>
                 {t('bounties.portal.judge.splitChildNote', 'Points are awarded to the primary PR in this group only.')}
               </p>
             )}
+          </div>
+        )}
+
+        {pr.status === 'detected' && (
+          <div className="border-t border-gray-100 dark:border-white/10 pt-4">
+            <SectionLabel className="block mb-2">
+              {t('bounties.portal.judge.actions', 'ACTIONS')}
+            </SectionLabel>
+            <div className="flex gap-2">
+              <ActionButton
+                onClick={handleRerunAiCheck}
+                loading={actionLoading === `/api/bounties/portal/judge/prs/${pr.id}/rerun-ai`}
+                variant="neutral"
+              >
+                <RefreshCw className="size-3.5" />
+                {t('bounties.portal.judge.runAiCheck', 'Run AI Check')}
+              </ActionButton>
+            </div>
           </div>
         )}
 

--- a/src/modules/bounties/i18n/en.json
+++ b/src/modules/bounties/i18n/en.json
@@ -50,10 +50,13 @@
   "bounties.actions.reject": "Reject",
   "bounties.actions.approveInstead": "Approve Instead",
   "bounties.actions.adjust": "Adjust",
+  "bounties.actions.runAiCheck": "Run AI Check",
+  "bounties.actions.runningAiCheck": "Running AI Check...",
   "bounties.actions.ungroup": "Ungroup",
 
   "bounties.flash.approved": "PR approved",
   "bounties.flash.rejected": "PR rejected",
+  "bounties.flash.aiCheckQueued": "AI classification queued",
   "bounties.flash.pointsAdjusted": "Points adjusted",
   "bounties.flash.ungrouped": "Split group removed — individual scoring restored",
 


### PR DESCRIPTION
## Summary
- add backend and portal judge endpoints to manually queue AI classification for detected bounty PRs
- add a Run AI Check action in both judging detail panels for PRs stuck in Detected state
- add user-facing copy for the new action and success flash

## Verification
- yarn generate
- yarn typecheck